### PR TITLE
chunk output to console in rmarkdown template

### DIFF
--- a/inst/rmarkdown/templates/mc_markdown_temp/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/mc_markdown_temp/skeleton/skeleton.Rmd
@@ -3,6 +3,8 @@ title: "Untitled"
 output:
   github_document:
     df_print: kable
+editor_options: 
+  chunk_output_type: console
 ---
 
 ```{r setup, include=FALSE}


### PR DESCRIPTION
I usually change this in all of my markdown documents.  I know this is mostly personal preference, so if most people don't do this, it can be left as is.